### PR TITLE
Rename the env vars to be about Solr specifically

### DIFF
--- a/generate-env.sh
+++ b/generate-env.sh
@@ -3,29 +3,29 @@
 set -e
 
 CURRENT_CONTEXT=$(kubectl config current-context)
-K8S_CLUSTER_CA_CERTIFICATE=$(kubectl config view --raw -o json | jq -r '.clusters[]| select(.name | contains("'${CURRENT_CONTEXT}'"))  .cluster["certificate-authority-data"]')
-K8S_TOKEN=$(kubectl get secret $( kubectl get serviceaccount default -n default -o json | jq -r '.secrets[0].name' ) -n default -o json | jq -r .data.token)
+SOLR_CLUSTER_CA_CERTIFICATE=$(kubectl config view --raw -o json | jq -r '.clusters[]| select(.name | contains("'${CURRENT_CONTEXT}'"))  .cluster["certificate-authority-data"]')
+SOLR_TOKEN=$(kubectl get secret $( kubectl get serviceaccount default -n default -o json | jq -r '.secrets[0].name' ) -n default -o json | jq -r .data.token)
 
 # We need the Docker-internal control plane URL to be resolved for the CSB
 # when running in a container
-K8S_DOCKER_SERVER=$(kind get kubeconfig --internal --name=$(kind get clusters | grep datagov-broker-test) | grep server | cut -d ' ' -f 6-)
+SOLR_DOCKER_SERVER=$(kind get kubeconfig --internal --name=$(kind get clusters | grep datagov-broker-test) | grep server | cut -d ' ' -f 6-)
 
 # We need the localhost control plan URL to be used for direct access when we
 # work outside the CSB
-K8S_LOCALHOST_SERVER=$(kind get kubeconfig --name=$(kind get clusters | grep datagov-broker-test) | grep server | cut -d ' ' -f 6-)
+SOLR_LOCALHOST_SERVER=$(kind get kubeconfig --name=$(kind get clusters | grep datagov-broker-test) | grep server | cut -d ' ' -f 6-)
 
 # Generate the environment variables needed for configuring the CSB running in Docker
-echo K8S_SERVER=${K8S_DOCKER_SERVER} > .env
-echo K8S_TOKEN=${K8S_TOKEN} >> .env
-echo K8S_CLUSTER_CA_CERTIFICATE=${K8S_CLUSTER_CA_CERTIFICATE} >> .env
-echo K8S_NAMESPACE=default >> .env
-echo K8S_DOMAIN_NAME=ing.local.domain >> .env
+echo SOLR_SERVER=${SOLR_DOCKER_SERVER} > .env
+echo SOLR_TOKEN=${SOLR_TOKEN} >> .env
+echo SOLR_CLUSTER_CA_CERTIFICATE=${SOLR_CLUSTER_CA_CERTIFICATE} >> .env
+echo SOLR_NAMESPACE=default >> .env
+echo SOLR_DOMAIN_NAME=ing.local.domain >> .env
 
 # Generate terraform.tfvars needed for mucking about directly with terraform/provision
 cat > terraform/provision/terraform.tfvars << HEREDOC
-server="${K8S_LOCALHOST_SERVER}"
-token="${K8S_TOKEN}"
-cluster_ca_certificate="${K8S_CLUSTER_CA_CERTIFICATE}"
+server="${SOLR_LOCALHOST_SERVER}"
+token="${SOLR_TOKEN}"
+cluster_ca_certificate="${SOLR_CLUSTER_CA_CERTIFICATE}"
 namespace="default"
 domain_name="ing.local.domain"
 replicas=3

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,6 @@
 packversion: 1
 name: datagov-services-pak
-version: 0.12.0
+version: 0.13.0
 metadata:
   author: Bret Mogilefsky
 platforms:
@@ -32,8 +32,8 @@ service_definitions:
 parameters: []
 required_env_variables: []
 env_config_mapping:
-  K8S_SERVER: k8s.server
-  K8S_CLUSTER_CA_CERTIFICATE: k8s.cluster_ca_certificate
-  K8S_TOKEN: k8s.token
-  K8S_NAMESPACE: k8s.namespace
-  K8S_DOMAIN_NAME: k8s.domain_name
+  SOLR_SERVER: solr.server
+  SOLR_CLUSTER_CA_CERTIFICATE: solr.cluster_ca_certificate
+  SOLR_TOKEN: solr.token
+  SOLR_NAMESPACE: solr.namespace
+  SOLR_DOMAIN_NAME: solr.domain_name

--- a/solr-cloud.yml
+++ b/solr-cloud.yml
@@ -49,27 +49,27 @@ provision:
     type: string
     details: "The service URL (for your target k8s)"
     overwrite: true
-    default: ${config("k8s.server")}
+    default: ${config("solr.server")}
   - name: cluster_ca_certificate
     overwrite: true
     type: string
     details: "The CA certificate (for your target k8s)"
-    default: ${config("k8s.cluster_ca_certificate")}
+    default: ${config("solr.cluster_ca_certificate")}
   - name: token
     overwrite: true
     type: string
     details: "The service account token (for your target k8s)"
-    default: ${config("k8s.token")}
+    default: ${config("solr.token")}
   - name: namespace
     overwrite: true
     type: string
     details: The namespace (where you want SolrClouds deployed in your target k8s)
-    default: ${config("k8s.namespace")}
+    default: ${config("solr.namespace")}
   - name: domain_name
     overwrite: true
     type: string
     details: The domain to use for ingress (for your target k8s)
-    default: ${config("k8s.domain_name")}
+    default: ${config("solr.domain_name")}
   - name: replicas
     default: 3
     overwrite: false
@@ -94,19 +94,19 @@ bind:
   user_inputs: []
   computed_inputs:
   - name: namespace
-    default: ${config("k8s.namespace")}
+    default: ${config("solr.namespace")}
     overwrite: true
     type: string
   - name: server
-    default: ${config("k8s.server")}
+    default: ${config("solr.server")}
     overwrite: true
     type: string
   - name: cluster_ca_certificate
-    default: ${config("k8s.cluster_ca_certificate")}
+    default: ${config("solr.cluster_ca_certificate")}
     overwrite: true
     type: string
   - name: token
-    default: ${config("k8s.token")}
+    default: ${config("solr.token")}
     overwrite: true
     type: string
   - name: cloud_name


### PR DESCRIPTION
This way a different set of k8s credentials can be used per service if needed