### PR TITLE
Change default solr tag to a CKAN compatible tag

### DIFF
--- a/solr-cloud.yml
+++ b/solr-cloud.yml
@@ -75,7 +75,7 @@ provision:
     overwrite: false
     type: number
   - name: solrImageTag
-    default: "8.6"
+    default: "6.6.6-slim"
     overwrite: false
     type: string
   - name: solrJavaMem


### PR DESCRIPTION
https://github.com/GSA/datagov-deploy/issues/2924

Change the default solr tag to 6.6.6-slim. We know 6.6.6 is compatible with CKAN 2.8, let's start there.