### PR TITLE
Expose mem and cpu params with defaults for prod and test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,3 +40,7 @@ jobs:
     
     - name: Start the broker and run the tests
       run: make up test
+
+    - name: Clean up if there was a failure
+      if: ${{ failure() }}
+      run: make demo-down down

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ test-env-up: ## Set up a Kubernetes test environment using KinD
       --selector=app.kubernetes.io/component=controller \
       --timeout=90s
 
-.env: $(HOME)/.kube/config
+.env: $(HOME)/.kube/config generate-env.sh
 	@echo Generating a .env file containing k8s config for the broker
 	@./generate-env.sh > .env
 
@@ -94,7 +94,7 @@ test-env-down: ## Tear down the Kubernetes test environment in KinD
 	kind delete cluster --name datagov-broker-test
 	@rm .env
 
-all: clean build up test down ## Clean and rebuild, then bring up the server, run the examples, and bring the system down
+all: clean build test-env-up up test down test-env-down ## Clean and rebuild, start test environment, run the broker, run the examples, and tear the broker and test env down
 .PHONY: all clean build up down test demo-up demo-down test-env-up test-env-down
 
 examples.json:

--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,8 @@ test-env-up: ## Set up a Kubernetes test environment using KinD
 	# (This is necessary for the service account to be able to create the cluster-wide
 	# Solr CRD definitions.)
 	@kubectl create clusterrolebinding default-sa-cluster-admin --clusterrole=cluster-admin --serviceaccount=default:default --namespace=default
-	@helm install --namespace kube-system --repo https://charts.pravega.io zookeeper zookeeper-operator
-	@helm install --namespace kube-system --repo https://solr.apache.org/charts solr solr-operator
+	@helm install --namespace kube-system --repo https://charts.pravega.io --version 0.2.9 zookeeper zookeeper-operator
+	@helm install --namespace kube-system --repo https://solr.apache.org/charts --version 0.2.8 solr solr-operator
 	# Install a KinD-flavored ingress controller (to make the Solr instances visible to the host)
 	# See (https://kind.sigs.k8s.io/docs/user/ingress/#ingress-nginx for details
 	@kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/kind/deploy.yaml

--- a/Makefile
+++ b/Makefile
@@ -52,12 +52,16 @@ down: ## Bring the cloud-service-broker service down
 # $(CSB) client run-examples --filename examples.json
 # ...to test the brokerpak. However, some of our examples need to run nested.
 # So, we'll run them manually with eden via "demo-up" and "demo-down" targets.
-test: examples.json demo-up demo-down ## Execute the brokerpak examples against the running broker
+test: examples.json demo-up demo-run demo-down ## Execute the brokerpak examples against the running broker
 
 demo-up: examples.json ## Provision a SolrCloud instance and output the bound credentials
 	@$(EDEN_EXEC) provision -i instance -s ${SERVICE_NAME} -p ${PLAN_NAME} -P '$(CLOUD_PROVISION_PARAMS)'
 	@$(EDEN_EXEC) bind -b binding -i instance
 	@$(EDEN_EXEC) credentials -b binding -i instance
+
+demo-run: ## Run tests on the demo instance
+	INSTANCE_NAME=${INSTANCE_NAME} ./test.sh
+
 demo-down: examples.json ## Clean up data left over from tests and demos
 	@echo "Unbinding and deprovisioning the ${SERVICE_NAME} instance"
 	-@$(EDEN_EXEC) unbind -b binding -i instance 2>/dev/null

--- a/README.md
+++ b/README.md
@@ -32,32 +32,66 @@ brokerpak concept, and to the Pivotal team running with the concept!
 
 Run the `make` command by itself for information on the various targets that are available. 
 
-```
+```bash
 $ make
-clean      Bring down the broker service if it's up, clean out the database, and remove created images
-build      Build the brokerpak(s) and create a docker image for testing it/them
-up         Run the broker service with the brokerpak configured. The broker listens on `0.0.0.0:8080`. curl http://127.0.0.1:8080 or visit it in your browser.
-wait       Wait 40 seconds, enough time for the DB and broker to stabilize
-test       Execute the brokerpak examples against the running broker
+clean      Bring down the broker service if it's up and clean out the database
+build      Build the brokerpak(s)
+up         Run the broker service with the brokerpak configured. The broker listens on `0.0.0.0:8080`. curl http://127.0.0.1:8080 or visit it in your browser. 
 down       Bring the cloud-service-broker service down
-all        Clean and rebuild, then bring up the server, run the examples, and bring the system down
+test       Execute the brokerpak examples against the running broker
+demo-up    Provision a SolrCloud instance and output the bound credentials
+demo-down  Clean up data left over from tests and demos
+test-env-up Set up a Kubernetes test environment using KinD
+test-env-down Tear down the Kubernetes test environment in KinD
+all        Clean and rebuild, start test environment, run the broker, run the examples, and tear the broker and test env down
 help       This help
 ```
-Notable targets are described below
 
-## Building and starting the brokerpak 
+Notable targets are described below.
+
+## Operating a test/demo Kubernetes environment
+
+### Creating the environment
+
+Create a temporary Kubernetes cluster to test against with KinD:
+
+```bash
+make test-env-up
+```
+
+### Tearing down the environment
+
 Run 
 
+```bash
+make test-env-down
 ```
+
+## Iterating on the Terraform code
+
+To work with the Terraform and KinD cluster directly (eg not through the CSB or brokerpak), you can generate an appropriate .tfvars file by running:
+
+```bash
+make .env
+```
+
+From that point on, you can `cd terraform/provision` and iterate with `terraform init/plan/apply/etc`. The same configuration is also available in `terraform/bind`.
+
+## Building and starting the brokerpak (while the test environment is available)
+
+Run
+
+```bash
 make build up 
 ```
 
 The broker will start and (after about 40 seconds) listen on `0.0.0.0:8080`. You
 test that it's responding by running:
-```
-curl -i -H "X-Broker-API-Version: 2.16" http://user:pass@127.0.0.1:8080/v2/catalog
 
+```bash
+curl -i -H "X-Broker-API-Version: 2.16" http://user:pass@127.0.0.1:8080/v2/catalog
 ```
+
 In response you will see a YAML description of the services and plans available
 from the brokerpak.
 
@@ -69,137 +103,78 @@ Precondition Failed`, and browsers will show that status as `Not Authorized`.)
 You can also inspect auto-generated documentation for the brokerpak's offerings
 by visiting [`http://127.0.0.1:8080/docs`](http://127.0.0.1:8080/docs) in your browser.
 
-## Operating a test/demo Kubernetes environment
-
-### Creating the environment
-Create a temporary Kubernetes cluster to test against with KinD:
-```
-make test-env-up
-```
-### Tearing down the environment
-Run 
-```
-make test-env-down
-```
-
 ## Demonstrating operation
 
 ### Spinning up a demo instance
 
 Run
-```
+
+```bash
 make demo-up
 ```
 
-The examples and values in the `examples.json` file will be used to:
-- Provision and bind a solr-cloud instance
+The examples and values in the `examples.json` file will be used to provision and bind a solr-cloud instance.
 
-Once the solr-cloud instance is running, you will see a URL for accessing it.
-Open that URL in your browser. 
-
-You are likely to see `503 Service Temporarily
-Unavailable` as it takes a while for the SolrCloud instance to be ready for
+It takes a while for the SolrCloud instance to be ready for
 client connections (up to 12 minutes on Bret's workstation). You can monitor the
 progress by running:
-```
+
+```bash
 watch kubectl get all -n default
 ```
-When there is at least one `pod/example-solrcloud-<n>` with status showing `Running` and
-Ready showing `1/1`, then reload the provided URL in your browser to see the SolrCloud dashboard.
+
+The service will be available once there is at least one `pod/example-solrcloud-<n>` with status showing `Running` and Ready showing `1/1`. The output of `make` will display a URL with credentials for accessing it. Open the provided URL in your browser to see the SolrCloud dashboard.
 
 ### Spinning down the demo instance
 
 Run
-```
+
+```bash
 make demo-down
 ```
-The examples and values in the `examples.json` file will be used to:
-- Unbind and deprovision the solr-cloud instance
+
+The examples and values in the `examples.json` file will be used to unbind and deprovision the solr-cloud instance.
 
 Any stray resources left over from a failed demo will also be removed, so you
 can use this command to reset the environment.
-
 
 ## Running tests
 
 ### Testing automatically
 
 Run 
-```
+
+```bash
 make test
 ```
 
 The examples and values in the `examples.json` file will be used for end-to-end
 testing of the brokerpak:
+
 - Provision and bind a solr-cloud instance
 - Unbind and deprovision the solr-cloud instance
 
 ### Testing manually
 
-Run 
-```
-docker-compose exec -T broker /bin/cloud-service-broker client help
-```
-to get a list of available commands. You can further request help for each
-sub-command. Use this command to poke at the browser one request at a time.
+Run
 
-For example to see the catalog:
-```
-docker-compose exec -T broker /bin/cloud-service-broker client catalog
-```
-
-You can refer to the content of the `examples.json` file to manually provision
-and bind services. For example:
-
-```
-docker-compose exec -T broker /bin/cloud-service-broker client provision --instanceid <instancename> --serviceid f145c5aa-4cee-4570-8a95-9a65f0d8d9da  --planid 1779d7d5-874a-4352-b9c4-877be1f0745b --params "$(cat examples.json |jq '.[] | select(.service_name | contains("solr-cloud")) | .provision_params')"
-```
-
-...and so on.
-
-Using the CLI in this way will give you very precise JSON results for each
-query. For a more human-friendly workflow, use `eden` to manually manipulate the
-broker.
-
-For example, listing the catalog and provisioning a service instance with `eden`
-looks like this:
-```
-$ export SB_BROKER_URL=http://user:pass@127.0.0.1:8080
-$ export SB_BROKER_USERNAME=user
-$ export SB_BROKER_PASSWORD=pass
-$ eden catalog
-$ eden provision -s solr-cloud -p base -i <instance-name> -P "$(cat examples.json |jq '.[] | select(.service_name | contains("solr-cloud")) | .provision_params')"
-$ eden bind -i <instance-name>
-$ eden credentials -i <instance-name> -b <binding-name>
-```
-
-**NOTE:** The broker requires credentials for an accessible kubernetes cluster (eg in
-the cloud, or provided by Docker Desktop) when provisioning services. Currently we have no way to inject
-those credentials as `examples`, which are used as test cases, without
-compromising them. We've [requested
-this capability upstream in the
-broker](https://github.com/pivotal/cloud-service-broker/issues/108).
-
-In the meantime you can manipulate the broker manually. 
-
-### Testing manually
-
-Run 
-```
+```bash
 docker-compose exec -T broker /bin/cloud-service-broker client help"
 ```
+
 to get a list of available commands. You can further request help for each
 sub-command. Use this command to poke at the browser one request at a time.
 
 For example to see the catalog:
-```
+
+```bash
 docker-compose exec -T broker /bin/cloud-service-broker client catalog"
 ```
 
 To provision a service, copy `k8s-creds.yml-template` and edit it to
 include the correct credentials for an accessible kubernetes service. Then run:
 
-```
+```bash
 docker-compose exec -T broker /bin/cloud-service-broker client provision --instanceid <instancename> --serviceid f145c5aa-4cee-4570-8a95-9a65f0d8d9da  --planid 1779d7d5-874a-4352-b9c4-877be1f0745b --params "$(cat k8s-creds.yml)"
 ```
 
@@ -211,7 +186,8 @@ broker.
 
 For example, listing the catalog and provisioning a service instance with `eden`
 looks like this:
-```
+
+```bash
 $ export SB_BROKER_URL=http://user:pass@127.0.0.1:8080
 $ export SB_BROKER_USERNAME=user
 $ export SB_BROKER_PASSWORD=pass
@@ -221,11 +197,21 @@ $ eden bind -i <instance-name>
 $ eden credentials -i <instance-name> -b <binding-name>
 ```
 
+## Iterating on the brokerpak itself
+
+To rebuild the brokerpak and launch it, then provision a test instance:
+
+```bash
+make down build up demo-up
+# Poke and prod 
+make demo-down down
+```
+
 ## Tearing down the brokerpak
 
-Run 
+Run
 
-```
+```bash
 make down
 ```
 
@@ -233,10 +219,12 @@ The broker will be stopped.
 
 ## Cleaning out the current state
 
-Run 
-```
+Run
+
+```bash
 make clean
 ```
+
 The broker image, database content, and any built brokerpak files will be removed.
 
 ## Contributing

--- a/examples.json-template
+++ b/examples.json-template
@@ -5,7 +5,7 @@
     "service_name": "solr-cloud",
     "service_id": "b9013a91-9ce8-4c18-8035-a135a8cd6ff9",
     "plan_id": "e35e9675-413f-4f42-83de-ad5003357e77",
-    "provision_params": {},
+    "provision_params": {"solrJavaMem":"-Xms300m -Xmx300m", "solrMem":"500M", "solrCpu":"250m"},
     "bind_params": {}
   }
 ]

--- a/examples.json-template
+++ b/examples.json-template
@@ -5,7 +5,7 @@
     "service_name": "solr-cloud",
     "service_id": "b9013a91-9ce8-4c18-8035-a135a8cd6ff9",
     "plan_id": "e35e9675-413f-4f42-83de-ad5003357e77",
-    "provision_params": {"solrJavaMem":"-Xms300m -Xmx300m", "solrMem":"500M", "solrCpu":"250m"},
+    "provision_params": {"solrJavaMem":"-Xms300m -Xmx300m", "solrMem":"500M", "solrCpu":"250m", "cloud_name":"demo"},
     "bind_params": {}
   }
 ]

--- a/solr-cloud.yml
+++ b/solr-cloud.yml
@@ -82,6 +82,14 @@ provision:
     default: "-Xms4g -Xmx4g"
     overwrite: false
     type: string
+  - name: solrMem
+    default: "6G"
+    overwrite: false
+    type: string
+  - name: solrCpu
+    default: "2000m"
+    overwrite: false
+    type: string
   outputs: []
   template_refs: 
     main: terraform/provision/main.tf

--- a/terraform/provision/main.tf
+++ b/terraform/provision/main.tf
@@ -65,6 +65,18 @@ resource "helm_release" "solrcloud" {
   }
 
   set {
+    # How much memory to request from the scheduler
+    name  = "solrMem"
+    value = var.solrMem
+  }
+
+  set {
+    # How much vCPU to request from the scheduler
+    name  = "solrCpu"
+    value = var.solrCpu
+  }
+
+  set {
     # The name of the secret to be used for authentication
     name  = "secretName"
     value = kubernetes_secret.client_creds.metadata[0].name

--- a/terraform/provision/solr-crd/templates/solrcloud-crd.yaml
+++ b/terraform/provision/solr-crd/templates/solrcloud-crd.yaml
@@ -28,7 +28,6 @@ spec:
   solrJavaMem: {{ .Values.solrJavaMem | quote }}
   solrAddressability:
     external:
-      hideNodes: true
       method: Ingress
       domainName: {{ .Values.domainName | quote }}
   customSolrKubeOptions:

--- a/terraform/provision/solr-crd/templates/solrcloud-crd.yaml
+++ b/terraform/provision/solr-crd/templates/solrcloud-crd.yaml
@@ -32,6 +32,11 @@ spec:
       method: Ingress
       domainName: {{ .Values.domainName | quote }}
   customSolrKubeOptions:
+    podOptions:
+      resources:
+        requests:
+          memory: {{ .Values.solrMem | quote }}
+          cpu: {{ .Values.solrCpu | quote }}
     ingressOptions:
       annotations:
         nginx.ingress.kubernetes.io/auth-type: basic

--- a/terraform/provision/solr-crd/values.yaml
+++ b/terraform/provision/solr-crd/values.yaml
@@ -14,6 +14,12 @@ solrImageTag: 8.6
 # How much memory to give each container
 solrJavaMem: "-Xms4g -Xmx4g"
 
+# How much memory to request on the host node
+solrMem: "6G"
+
+# How much vCPU to request on the host node
+solrCpu: "2000m"
+
 # The name of a kubernetes secret that you'd like to use for auth
 secretName: basic-auth1
 

--- a/terraform/provision/variables.tf
+++ b/terraform/provision/variables.tf
@@ -34,6 +34,18 @@ variable "solrJavaMem" {
   default     = "-Xms4g -Xmx4g"
 }
 
+variable "solrMem" {
+  type        = string
+  description = "How much memory to request for each replica (default is '6G')"
+  default     = "6G"
+}
+
+variable "solrCpu" {
+  type        = string
+  description = "How much vCPU to request for each replica (default is '2000m' aka '2 vCPUs')"
+  default     = "2000m"
+}
+
 variable "cloud_name" {
   type        = string
   description = "The name of the cloud to create (used only for demo purposes)"

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+set -e
+echo "Running tests..."


### PR DESCRIPTION
Mainly: 
- Expose settings for the CPU and memory requests for the pods (in addition to the JVM memory parameters which were already exposed). 
- Set defaults appropriate for 4GB SolrCloud nodes, and uses the new parameters during testing to squinch the nodes down to something that will run in KinD on a local workstation.
- exposes the individual solrcloud nodes for better insight into how the parameters are working in the Solr dashboard

Also: 
- improves development workflow documentation
- adds hook for testing the demo SolrCloud
- cleans up resources if tests fails during a GitHub Action
